### PR TITLE
grad: remove amount raised display

### DIFF
--- a/src/pages/grad.astro
+++ b/src/pages/grad.astro
@@ -85,13 +85,7 @@ import Footer from "@/components/Footer";
                   <line x1="10" x2="10" y1="2" y2="4"/>
                   <line x1="14" x2="14" y1="2" y2="4"/>
                 </svg>
-                <span class="text-xs uppercase tracking-widest text-muted-foreground">Raised so far</span>
-              </div>
-              <div class="text-3xl md:text-4xl font-bold tracking-tight text-foreground" id="total-raised">
-                $0
-              </div>
-              <div class="mt-3 w-full h-2 rounded-full bg-secondary overflow-hidden">
-                <div class="h-full rounded-full bg-gradient-to-r from-[hsl(var(--color-pink))] to-[hsl(var(--color-purple))] transition-all duration-1000 ease-out" id="progress-bar" style="width: 0%"></div>
+                <span class="text-xs uppercase tracking-widest text-muted-foreground">Supporters</span>
               </div>
               <p class="text-xs text-muted-foreground/60 mt-2" id="supporter-count">0 supporters</p>
             </div>
@@ -155,14 +149,7 @@ import Footer from "@/components/Footer";
         100% { transform: translateX(100%); }
       }
 
-      @keyframes countUp {
-        from { opacity: 0; transform: translateY(10px); }
-        to { opacity: 1; transform: translateY(0); }
-      }
 
-      #total-raised {
-        animation: countUp 0.8s ease-out forwards;
-      }
     </style>
 
     <script is:inline>
@@ -193,39 +180,12 @@ import Footer from "@/components/Footer";
           if (!res.ok) return;
           const data = await res.json();
 
-          const totalEl = document.getElementById('total-raised');
-          const progressEl = document.getElementById('progress-bar');
           const countEl = document.getElementById('supporter-count');
-
-          if (totalEl && data.total !== undefined) {
-            // Animate the number counting up
-            const target = data.total;
-            const duration = 1500;
-            const start = performance.now();
-
-            function animate(now) {
-              const elapsed = now - start;
-              const progress = Math.min(elapsed / duration, 1);
-              const eased = 1 - Math.pow(1 - progress, 3); // ease-out cubic
-              const current = eased * target;
-              totalEl.textContent = '$' + current.toFixed(0);
-              if (progress < 1) requestAnimationFrame(animate);
-            }
-            requestAnimationFrame(animate);
-          }
 
           if (countEl && data.supporters !== undefined) {
             countEl.textContent = data.supporters + (data.supporters === 1 ? ' supporter' : ' supporters');
           }
-
-          // Animate progress bar (just visual flair, no fixed goal)
-          if (progressEl) {
-            // Use a logarithmic scale for visual effect since there's no goal
-            const pct = Math.min(100, Math.max(5, Math.sqrt(data.total || 0) * 5));
-            setTimeout(() => { progressEl.style.width = pct + '%'; }, 300);
-          }
         } catch (e) {
-          // Silently fail - the counter just stays at $0
           console.log('BMC stats unavailable');
         }
       }


### PR DESCRIPTION
Removes the dollar amount raised, progress bar, and count-up animation from the /grad page. Keeps the supporter count. Simplifies the JS to only update supporter data.

Separate from #10 (already merged).